### PR TITLE
Fix jitter overlaying points

### DIFF
--- a/diamonds.qmd
+++ b/diamonds.qmd
@@ -15,9 +15,9 @@ dataset <- diamonds
 # {.sidebar}
 
 ```{r}
-sliderInput('sampleSize', 'Sample Size', 
+sliderInput('sampleSize', 'Sample Size',
             min=1, max=nrow(dataset),
-            value=min(1000, nrow(dataset)), 
+            value=min(1000, nrow(dataset)),
             step=500, round=0)
 br()
 checkboxInput('jitter', 'Jitter', value = TRUE)
@@ -25,17 +25,17 @@ checkboxInput('smooth', 'Smooth', value = TRUE)
 ```
 
 ```{r}
-selectInput('x', 'X', names(dataset)) 
+selectInput('x', 'X', names(dataset))
 selectInput('y', 'Y', names(dataset), names(dataset)[[2]])
-selectInput('color', 'Color', c('None', names(dataset)), 
-             selected = "clarity")
+selectInput('color', 'Color', c('None', names(dataset)),
+            selected = "clarity")
 ```
 
 ```{r}
 selectInput('facet_row', 'Facet Row',
-  c(None='.', names(diamonds[sapply(diamonds, is.factor)])))
+            c(None='.', names(diamonds[sapply(diamonds, is.factor)])))
 selectInput('facet_col', 'Facet Column',
-  c(None='.', names(diamonds[sapply(diamonds, is.factor)])))
+            c(None='.', names(diamonds[sapply(diamonds, is.factor)])))
 ```
 
 # Plot
@@ -56,31 +56,34 @@ tableOutput('data')
 dataset <- reactive({
   diamonds[sample(nrow(diamonds), input$sampleSize),]
 })
- 
+
 output$plot <- renderPlot({
-  
+
   p <- ggplot(
-    dataset(), 
-    aes_string(x=input$x, y=input$y)) + geom_point()
-  
+    dataset(),
+    aes_string(x=input$x, y=input$y))
+
   if (input$color != 'None')
     p <- p + aes_string(color=input$color)
-  
+
   facets <- paste(input$facet_row, '~', input$facet_col)
   if (facets != '. ~ .')
     p <- p + facet_grid(facets)
-  
-  if (input$jitter)
+
+  if (input$jitter) {
     p <- p + geom_jitter()
+  } else {
+    p <- p + geom_point()
+  }
+    
   if (input$smooth)
     p <- p + geom_smooth()
-  
+
   p
-  
+
 })
 
 output$data <- renderTable({
   dataset()
 })
 ```
-


### PR DESCRIPTION
In the previous version, when a jitter was applied, it was overlayed on top of the points instead of replacing them. The fix corrects this by using an if-else statement.